### PR TITLE
add support for segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,109 @@
 ## nimbusdb
-
 Persistent Key-Value store based on Bitcask paper.
 
-Readme to be updated.
+nimbusdb is a fast, lightweight, and scalable key-value store written in golang, based on bitcask.
+
+nimbusdb maintains an active datafile to which data is written. When it crosses a threshold, the datafile is made inactive and new datafile is created.
+As time passes, expired/deleted keys take up space which is not useful; Hence, a process called `merge` is done which removes all expired/deleted keys and frees up space.
+
+## Features
+<details>
+  <summary>
+  Thread-Safe
+  </summary>
+  All operations are thread-safe. Read and Write operations can handle multiple operations from multiple goroutines at the same time with consistency.
+</details>
+
+<details>
+  <summary>
+  Portable
+  </summary>
+  Data is extremely portable since it is only a bunch of files. All you have to do is move the folder and open an DB connection at that path.
+</details>
+
+<details>
+  <summary>
+  Custom Expiry
+  </summary>
+  Supports custom expiry for keys. Default expiry is 1 week.
+</details>
+
+<details>
+  <summary>
+  Supports Merge
+  </summary>
+  Supports `Sync` which can be called periodically to remove expired/deleted keys from disk and free-up more space.
+</details>
+
+<details>
+  <summary>
+  Single disk-seek write
+  </summary>
+  Writes are just one disk seek since we're appending to the file.
+</details>
+
+<details>
+  <summary>
+  Block cache for faster reads.
+  </summary>
+  Blocks are cached for faster reads. Default size of an Block is 32KB.
+</details>
+
+## Documentation
+#### Open DB connection
+```go
+d, err := nimbusdb.Open(&nimbusdb.Options{Path: "/path/to/data/directory"})
+if err != nil {
+  // handle error
+}
+```
+
+#### Set
+```go
+kvPair := &nimbusdb.KeyValuePair{
+  Key:   []byte("key"),
+  Value: []byte("value"),
+  Ttl: 5 * time.Minute, // Optional, default is 1 week
+}
+setValue, err := d.Set(kvPair)
+if err != nil {
+  // handle error
+}
+```
+
+#### Get
+
+```go
+value, err := d.Get([]byte("key"))
+if err != nil {
+  // handle error
+}
+```
+
+#### Delete
+
+```go
+value, err := d.Get([]byte("key"))
+if err != nil {
+  // handle error
+}
+```
+
+#### Sync
+This does the merge process. This can be an expensive operation, hence it is better to run this periodically and whenever the traffic is low.
+
+```go
+err := d.Sync()
+if err != nil {
+  // handle error
+}
+```
+
+## Benchmarks
+![Screenshot 2023-12-23 at 4 08 56 AM](https://github.com/manosriram/nimbusdb/assets/38112857/76720f68-ad16-44ee-a408-12b06e6c051a)
+
+
+
 
 [Progress Board](https://trello.com/b/2eDSLLb3/nimbusdb) | [Streams](https://youtube.com/playlist?list=PLJALjJgNSDVo5veOf2apgMIE1QgN7IEfk) | [godoc](https://pkg.go.dev/github.com/manosriram/nimbusdb)
 

--- a/btree.go
+++ b/btree.go
@@ -8,16 +8,9 @@ import (
 	"github.com/manosriram/nimbusdb/utils"
 )
 
-type BlockOffsetPair struct {
-	startOffset int64
-	endOffset   int64
-	filePath    string
-}
-
 type BTree struct {
-	tree         *btree.BTree
-	blockOffsets map[int64]BlockOffsetPair
-	mu           sync.RWMutex
+	tree *btree.BTree
+	mu   sync.RWMutex
 }
 
 type item struct {
@@ -39,16 +32,6 @@ func (b *BTree) Get(key []byte) *KeyDirValue {
 
 func (b *BTree) Set(key []byte, value KeyDirValue) *KeyDirValue {
 	i := b.tree.ReplaceOrInsert(&item{key: key, v: value})
-	y, ok := b.blockOffsets[value.blockNumber]
-	if !ok {
-		y.startOffset = value.offset
-		y.endOffset = value.offset + value.size
-		y.filePath = value.path
-		b.blockOffsets[value.blockNumber] = y
-	} else {
-		y.endOffset = value.offset + value.size
-		b.blockOffsets[value.blockNumber] = y
-	}
 	if i != nil {
 		return &i.(*item).v
 	}

--- a/db.go
+++ b/db.go
@@ -57,7 +57,7 @@ const (
 )
 
 const (
-	KEY_EXPIRES_IN_DEFAULT = 24 * time.Hour
+	KEY_EXPIRES_IN_DEFAULT = 168 * time.Hour // 1 week
 
 	KEY_NOT_FOUND             = "key expired or does not exist"
 	NO_ACTIVE_FILE_OPENED     = "no file opened for writing"

--- a/db.go
+++ b/db.go
@@ -544,6 +544,8 @@ func (db *Db) createActiveDatafile(dirPath string) error {
 	return nil
 }
 
+// Closes the database. Closes the file pointer used to read/write the activeDataFile.
+// Closes all file inactiveDataFile pointers and marks them as closed.
 func (db *Db) Close() error {
 	if db.activeDataFilePointer != nil {
 		err := db.activeDataFilePointer.Close()
@@ -653,6 +655,8 @@ func (db *Db) deleteKey(key []byte) error {
 	return nil
 }
 
+// Gets a key-value pair.
+// Returns the value if the key exists and error if any.
 func (db *Db) Get(key []byte) ([]byte, error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
@@ -664,6 +668,8 @@ func (db *Db) Get(key []byte) ([]byte, error) {
 	return v.v, nil
 }
 
+// Sets a key-value pair.
+// Returns the value if set succeeds, else returns an error.
 func (db *Db) Set(kv *KeyValuePair) (interface{}, error) {
 
 	intKSz := int64(len(kv.Key))
@@ -701,6 +707,8 @@ func (db *Db) Set(kv *KeyValuePair) (interface{}, error) {
 	return kv.Value, err
 }
 
+// Deletes a key-value pair.
+// Returns error if any.
 func (db *Db) Delete(key []byte) error {
 	err := db.deleteKey(key)
 	return err
@@ -736,6 +744,8 @@ func (db *Db) walk(s string, file fs.DirEntry, err error) error {
 	return nil
 }
 
+// Syncs the database. Will remove all expired/deleted keys from disk.
+// Since items are removed, disk usage will reduce.
 func (db *Db) Sync() error {
 	err := filepath.WalkDir(db.dirPath, db.walk)
 	if err != nil {

--- a/examples/b.go
+++ b/examples/b.go
@@ -1,0 +1,15 @@
+// package main
+
+// import "fmt"
+
+// type y struct {
+// name string
+// }
+
+// func main() {
+// x := make(map[string]int)
+// x["z"] = 1
+
+// x["z"] += 100
+// fmt.Println(x)
+// }

--- a/examples/db.go
+++ b/examples/db.go
@@ -56,8 +56,6 @@ func main() {
 				fmt.Println(err)
 			}
 			fmt.Println(string(z))
-		} else if text == "stat" {
-			d.CreateActiveDatafile(DirPath)
 		} else if text == "sync" {
 			d.Sync()
 		}

--- a/segment.go
+++ b/segment.go
@@ -14,6 +14,12 @@ type Segment struct {
 	fp                 *os.File
 }
 
+type BlockOffsetPair struct {
+	startOffset int64
+	endOffset   int64
+	filePath    string
+}
+
 func (db *Db) getSegmentBlock(path string, blockNumber int64) (*BlockOffsetPair, bool) {
 	segment, ok := db.segments[path]
 	if !ok {
@@ -63,6 +69,12 @@ func (db *Db) setSegmentBlockNumber(path string, blockNumber int64) {
 func (db *Db) setSegmentBlockOffset(path string, blockOffset int64) {
 	segment := db.getSegment(path)
 	segment.currentBlockOffset = blockOffset
+	db.setSegment(path, segment)
+}
+
+func (db *Db) setSegmentBlock(path string, blockNumber int64, block *BlockOffsetPair) {
+	segment := db.getSegment(path)
+	segment.blocks[blockNumber] = block
 	db.setSegment(path, segment)
 }
 

--- a/segment.go
+++ b/segment.go
@@ -1,0 +1,56 @@
+package nimbusdb
+
+import (
+	"os"
+	"path/filepath"
+)
+
+type Segment struct {
+	path               string
+	fp                 *os.File
+	closed             bool
+	blocks             map[int64]*BlockOffsetPair
+	currentBlockNumber int64
+	currentBlockOffset int64
+}
+
+func (db *Db) getSegmentBlock(path string, blockNumber int64) (*BlockOffsetPair, bool) {
+	segment, ok := db.segments[path]
+	if !ok {
+		return nil, ok
+	}
+	block, ok := segment.blocks[blockNumber]
+	if !ok {
+		return nil, ok
+	}
+	return block, true
+}
+
+func (db *Db) getSegment(path string) *Segment {
+	return db.segments[path]
+}
+
+func (db *Db) setSegment(path string, segment *Segment) {
+	db.segments[path] = segment
+}
+
+func (db *Db) setSegmentPath(segmentPath string, path string) {
+	segment := db.getSegment(segmentPath)
+	segment.path = path
+	db.setSegment(path, segment)
+}
+
+func (db *Db) setSegmentFp(path string, fp *os.File) {
+	segment := db.getSegment(path)
+	segment.fp = fp
+	db.setSegment(path, segment)
+}
+
+func (db *Db) getSegmentFilePointerFromPath(keyDirPath string) (*os.File, error) {
+	path := filepath.Join(db.dirPath, keyDirPath)
+	f, err := os.OpenFile(path, os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}

--- a/segment.go
+++ b/segment.go
@@ -6,12 +6,12 @@ import (
 )
 
 type Segment struct {
-	path               string
-	fp                 *os.File
 	closed             bool
-	blocks             map[int64]*BlockOffsetPair
 	currentBlockNumber int64
 	currentBlockOffset int64
+	path               string
+	blocks             map[int64]*BlockOffsetPair
+	fp                 *os.File
 }
 
 func (db *Db) getSegmentBlock(path string, blockNumber int64) (*BlockOffsetPair, bool) {
@@ -30,6 +30,14 @@ func (db *Db) getSegment(path string) *Segment {
 	return db.segments[path]
 }
 
+func (db *Db) getSegmentBlockOffset(path string) int64 {
+	return db.segments[path].currentBlockOffset
+}
+
+func (db *Db) getSegmentBlockNumber(path string) int64 {
+	return db.segments[path].currentBlockNumber
+}
+
 func (db *Db) setSegment(path string, segment *Segment) {
 	db.segments[path] = segment
 }
@@ -43,6 +51,18 @@ func (db *Db) setSegmentPath(segmentPath string, path string) {
 func (db *Db) setSegmentFp(path string, fp *os.File) {
 	segment := db.getSegment(path)
 	segment.fp = fp
+	db.setSegment(path, segment)
+}
+
+func (db *Db) setSegmentBlockNumber(path string, blockNumber int64) {
+	segment := db.getSegment(path)
+	segment.currentBlockNumber = blockNumber
+	db.setSegment(path, segment)
+}
+
+func (db *Db) setSegmentBlockOffset(path string, blockOffset int64) {
+	segment := db.getSegment(path)
+	segment.currentBlockOffset = blockOffset
 	db.setSegment(path, segment)
 }
 

--- a/segment.go
+++ b/segment.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 )
 
+// Segment represents an entire file. It is divided into Blocks.
+// Each Segment is a collection of Blocks of size 32KB. A file pointer is kept opened for reading purposes.
+// closed represents the state of the Segment's file pointer.
 type Segment struct {
 	closed             bool
 	currentBlockNumber int64
@@ -14,6 +17,7 @@ type Segment struct {
 	fp                 *os.File
 }
 
+// BlockOffsetPair contains metadata about the Block. The start and ending offsets of the Block, and the path.
 type BlockOffsetPair struct {
 	startOffset int64
 	endOffset   int64

--- a/tests/db_test.go
+++ b/tests/db_test.go
@@ -90,7 +90,7 @@ func Test_InMemory_Stress_SetGet(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	for i := 0; i < 100000; i++ {
+	for i := 0; i < 1000; i++ {
 		kv := &nimbusdb.KeyValuePair{
 			Key:   []byte(utils.GetTestKey(i)),
 			Value: []byte("testkey"),

--- a/wal.go
+++ b/wal.go
@@ -1,9 +1,6 @@
 package nimbusdb
 
 import (
-	"os"
-	"time"
-
 	"github.com/manosriram/nimbusdb/utils"
 )
 
@@ -65,26 +62,11 @@ func (s *KeyValueEntry) ToByte() []byte {
 	return keyValueEntryInBytes
 }
 
-func (db *Db) WriteKeyValueEntry(keyValueEntry *KeyValueEntry) error {
+func (db *Db) writeKeyValueEntry(keyValueEntry *KeyValueEntry) error {
 	f, err := db.getActiveDataFilePointer()
 	if err != nil {
 		return err
 	}
 	_, err = f.Write(keyValueEntry.ToByte())
 	return err
-}
-
-func (db *Db) ExpireKey(offset int64) error {
-	f, err := os.OpenFile(db.activeDataFile, os.O_RDWR, 0644)
-	if err != nil {
-		return err
-	}
-
-	expireTstamp := time.Now().Add(-1 * time.Hour).UnixNano()
-	_, err = f.WriteAt(utils.Int64ToByte(expireTstamp), int64(offset))
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/wal.go
+++ b/wal.go
@@ -4,6 +4,8 @@ import (
 	"github.com/manosriram/nimbusdb/utils"
 )
 
+// KeyValueEntry is the raw and complete uncompressed data existing on the disk.
+// KeyValueEntry is stored in Blocks in cache for faster reads.
 type KeyValueEntry struct {
 	deleted     byte
 	blockNumber int64
@@ -17,6 +19,8 @@ type KeyValueEntry struct {
 	fileID      string
 }
 
+// Block represents a single block of disk memory. Default size is 32KB.
+// Each Segment is a collection of blocks; Each block is a collection of KeyValueEntries.
 type Block struct {
 	entries     []*KeyValueEntry
 	blockNumber int64

--- a/wal.go
+++ b/wal.go
@@ -26,15 +26,6 @@ type Block struct {
 	blockOffset int64
 }
 
-type Segment struct {
-	path               string
-	fp                 *os.File
-	closed             bool
-	blocks             map[int64]*BlockOffsetPair
-	currentBlockNumber int64
-	currentBlockOffset int64
-}
-
 func (s *KeyValueEntry) StaticChunkSize() int {
 	return StaticChunkSize + len(s.k) + len(s.v)
 }

--- a/wal.go
+++ b/wal.go
@@ -10,7 +10,6 @@ import (
 type KeyValueEntry struct {
 	deleted     byte
 	blockNumber int64
-	fileID      string
 	offset      int64
 	size        int64 // Equals StaticChunkSize + keysize + valuesize
 	tstamp      int64
@@ -18,6 +17,7 @@ type KeyValueEntry struct {
 	vsz         int64
 	k           []byte
 	v           []byte
+	fileID      string
 }
 
 type Block struct {

--- a/wal.go
+++ b/wal.go
@@ -26,6 +26,15 @@ type Block struct {
 	blockOffset int64
 }
 
+type Segment struct {
+	path               string
+	fp                 *os.File
+	closed             bool
+	blocks             map[int64]*BlockOffsetPair
+	currentBlockNumber int64
+	currentBlockOffset int64
+}
+
 func (s *KeyValueEntry) StaticChunkSize() int {
 	return StaticChunkSize + len(s.k) + len(s.v)
 }

--- a/wal.go
+++ b/wal.go
@@ -26,6 +26,17 @@ type Block struct {
 	blockOffset int64
 }
 
+func NewKeyValueEntry(deleted byte, offset, ksz, vsz, size int64, k, v []byte) *KeyValueEntry {
+	return &KeyValueEntry{
+		deleted: deleted,
+		ksz:     ksz,
+		vsz:     vsz,
+		size:    size,
+		k:       k,
+		v:       v,
+	}
+}
+
 func (s *KeyValueEntry) StaticChunkSize() int {
 	return StaticChunkSize + len(s.k) + len(s.v)
 }


### PR DESCRIPTION
Introduce hierarchy to datablocks. follows Segment > Block > (KeyValueEntry | KeyDirValue)

- Segment: Each file is a segment. Either datafile (.dfile) or inactive-datafile (.idfile).
- Block: Segment is divided into blocks. Each block is of 32KB size.
- KeyValueEntry: Each KeyValue and its metadata is stored as KeyValueEntry. If not cached, this will be KeyDirValue inmemory.