### PR TITLE
refactor: make return values of db and batch Set, SetWithTTL, and Delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ kvPair := &nimbusdb.KeyValuePair{
   Value: []byte("value"),
   Ttl: 5 * time.Minute, // Optional, default is 1 week
 }
-setValue, err := d.Set(kvPair)
+key, err := d.Set(kvPair)
 if err != nil {
   // handle error
 }
@@ -94,17 +94,7 @@ if err != nil {
 #### Delete
 
 ```go
-value, err := d.Delete([]byte("key"))
-if err != nil {
-  // handle error
-}
-```
-
-#### Sync
-This does the merge process. This can be an expensive operation, hence it is better to run this periodically and whenever the traffic is low.
-
-```go
-err := d.Sync()
+key, err := d.Delete([]byte("key"))
 if err != nil {
   // handle error
 }
@@ -123,7 +113,7 @@ if err != nil {
 }
 defer b.Close()
 
-_, err = b.Set([]byte("key"), []byte("value")) // not written to disk yet.
+key, err = b.Set([]byte("key"), []byte("value")) // not written to disk yet.
 if err != nil {
   // handle error
 }
@@ -133,7 +123,7 @@ if err != nil {
   // handle error
 }
 
-err = b.Delete([]byte("key"))
+key, err = b.Delete([]byte("key"))
 if err != nil {
   // handle error
 }
@@ -186,17 +176,17 @@ func main() {
     Key:   []byte("key"),
     Value: []byte("value"),
   }
-  setValue, err := d.Set(kvPair) // will trigger an CREATE event
+  key, err := d.Set(kvPair) // will trigger an CREATE event
   if err != nil {
     // handle error
   }
 
-  setValue, err := d.Set(kvPair) // will trigger an UPDATE event
+  key, err = d.Set(kvPair) // will trigger an UPDATE event
   if err != nil {
     // handle error
   }
 
-  err = d.Delete(kvPair.Key) // will trigger an DELETE event
+  key, err = d.Delete(kvPair.Key) // will trigger an DELETE event
   if err != nil {
     // handle error
   }

--- a/batch.go
+++ b/batch.go
@@ -156,11 +156,11 @@ func (b *Batch) SetWithTTL(k []byte, v []byte, ttl time.Duration) ([]byte, error
 	return v, nil
 }
 
-func (b *Batch) Delete(k []byte) error {
+func (b *Batch) Delete(k []byte) ([]byte, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.closed {
-		return ERROR_BATCH_CLOSED
+		return nil, ERROR_BATCH_CLOSED
 	}
 
 	index := -1
@@ -176,13 +176,13 @@ func (b *Batch) Delete(k []byte) error {
 		b.writeQueue[len(b.writeQueue)-1] = nil
 		b.writeQueue = b.writeQueue[:len(b.writeQueue)-1]
 	} else {
-		err := b.db.Delete(k)
+		_, err := b.db.Delete(k)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		return nil
+		return k, nil
 	}
-	return nil
+	return k, nil
 }
 
 func (b *Batch) Commit() error {

--- a/batch_test.go
+++ b/batch_test.go
@@ -180,7 +180,7 @@ func Test_Batch_Delete(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, value, va)
 
-	err = b.Delete(key)
+	_, err = b.Delete(key)
 	assert.Nil(t, err)
 
 	_, err = d.Get(key)
@@ -270,7 +270,7 @@ func Test_Batch_ConcurrentDelete(t *testing.T) {
 		key := []byte(utils.GetTestKey(i))
 		go func() {
 			defer wg.Done()
-			err := b.Delete(key)
+			_, err := b.Delete(key)
 			assert.Nil(t, err)
 
 			_, err = b.Get(key)

--- a/db.go
+++ b/db.go
@@ -656,7 +656,7 @@ func (db *Db) Set(k []byte, v []byte) ([]byte, error) {
 	return v, err
 }
 
-func (db *Db) SetWithTTL(k []byte, v []byte, ttl time.Duration) (interface{}, error) {
+func (db *Db) SetWithTTL(k []byte, v []byte, ttl time.Duration) ([]byte, error) {
 	intKSz := int64(len(k))
 	intVSz := int64(len(utils.Encode(v)))
 
@@ -709,15 +709,15 @@ func (db *Db) SetWithTTL(k []byte, v []byte, ttl time.Duration) (interface{}, er
 
 // Deletes a key-value pair.
 // Returns error if any.
-func (db *Db) Delete(key []byte) error {
+func (db *Db) Delete(k []byte) ([]byte, error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	err := db.deleteKey(key)
+	err := db.deleteKey(k)
 	if db.opts.ShouldWatch {
-		db.SendWatchEvent(NewDeleteWatcherEvent(key, nil, nil, nil))
+		db.SendWatchEvent(NewDeleteWatcherEvent(k, nil, nil, nil))
 	}
-	return err
+	return k, err
 }
 
 func (db *Db) walk(s string, file fs.DirEntry, err error) error {

--- a/db_test.go
+++ b/db_test.go
@@ -126,7 +126,7 @@ func Test_Delete(t *testing.T) {
 
 	key := []byte("testkey")
 	// value := []byte("testvalue")
-	err = d.Delete(key)
+	_, err = d.Delete(key)
 	assert.Equal(t, nil, err)
 
 	_, err = d.Get(key)
@@ -152,7 +152,7 @@ func Test_InMemory_Delete(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, value, va)
 
-	err = d.Delete(key)
+	_, err = d.Delete(key)
 	assert.Equal(t, nil, err)
 
 	va, err = d.Get(key)
@@ -261,7 +261,7 @@ func Test_ConcurrentDelete(t *testing.T) {
 		}
 		go func() {
 			defer wg.Done()
-			err := d.Delete(kv.Key)
+			_, err := d.Delete(kv.Key)
 			assert.Nil(t, err)
 
 			_, err = d.Get(kv.Key)

--- a/watch_test.go
+++ b/watch_test.go
@@ -85,7 +85,7 @@ func Test_Watch_Delete(t *testing.T) {
 	_, err = d.Set(k, v)
 	assert.Nil(t, err)
 
-	err = d.Delete(k)
+	_, err = d.Delete(k)
 	assert.Nil(t, err)
 
 	createEvent := <-ch


### PR DESCRIPTION
consistent.

- Update README